### PR TITLE
Add historyApiFallback to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   devServer: {
     contentBase: path.join(__dirname, "./dist/"),
+    historyApiFallback: true,
     hot: true
   },
   devtool: "source-map",


### PR DESCRIPTION
Suppresses issue where urls cannot be accessed directly from changing the url in the browser