### PR TITLE
Correctly set mode in webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "start": "webpack-dev-server --open"
+    "start": "webpack-dev-server --open --mode=development"
   },
   "author": "jcole",
   "license": "ISC",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, "./dist/"),
     filename: "bundle.js",
   },
-  mode: "none",
+  mode: "production",
   devServer: {
     static: path.join(__dirname, "./dist/"),
     historyApiFallback: true,


### PR DESCRIPTION
Currently hardcoded to `none` which is breaking Vercel deployments