### PR TITLE
Remove .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-API_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 bundle.js
 /dist
+.env

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: "./index.html",
     }),
-    new Dotenv(),
+    new Dotenv({ systemvars: true }),
   ],
 };


### PR DESCRIPTION
After recent changes to webpack and dotenv, `.env` was being used be Vercel during deployments and system vars like those exposed by Vercel were not exposed to the app